### PR TITLE
Fix documentation commit failing when docs/ is untracked

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -128,6 +128,7 @@ namespace :documentation do
 
     skip_ci = args.skip == 'true'
 
+    sh('git', 'add', 'docs')
     sh('git', 'commit',
        '-a',
        '-m', "Generate latest documentation#{' [ci skip]' if skip_ci}")


### PR DESCRIPTION
## Problem

The `Main` workflow's release job runs `./go documentation:update`, which generates YARD docs into `docs/` and then runs `documentation:commit`. That task uses `git commit -a`.

`docs/` has never been committed in this repo, so YARD's output is **untracked**. `git commit -a` only stages *tracked* modifications — it cannot stage untracked files — so nothing was staged and the commit exited non-zero, failing the release (observed in run 29848832808). This was the first real release to exercise `documentation:update`, so the latent bug only surfaced now.

## Fix

Add `sh('git', 'add', 'docs')` before the commit in the `documentation:commit` task, so newly generated documentation is staged and included in the commit.

## Verification (locally, ruby 3.3.11)

- `bundle install` — clean
- `bundle exec rake documentation:generate` then `git status` — confirmed `docs/` shows as untracked (`?? docs/`)
- `bundle exec rake documentation:commit` — now succeeds (exit 0), producing commit "Generate latest documentation [ci skip]" including `docs/`
- `bundle exec rake rubocop` — no offenses
- `bundle exec rake test:unit` — 14 examples, 0 failures

The generated-docs commit was dropped locally; this PR contains only the one-line Rakefile change, since CI regenerates docs at release time.